### PR TITLE
Return an object instead of a string when format is json

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -10,6 +10,8 @@ exports.create = function(config, fn){
         qs: config.qs || {},
         proxy: config.proxy
     }
+    if (config.format.toLowerCase() === "json")
+        options.json = true;
 
     request(options, function(err, response, body){
         fn(err, body);


### PR DESCRIPTION
Currently the data is returned as a string, generally people want this to be an object when the response format is JSON (which it is by default).

If users do in fact want a string, they can just do a `JSON.stringify()`, or if #10 was accepted they could access `response.body`.

Breaking change so would need a minor version bump if accepted.
